### PR TITLE
Fix active_support require

### DIFF
--- a/lib/zhong.rb
+++ b/lib/zhong.rb
@@ -4,6 +4,7 @@ require "logger"
 require "msgpack"
 require "redis"
 require "suo"
+require "active_support"
 require "active_support/time"
 
 require "zhong/version"


### PR DESCRIPTION
Was causing the following error:
```
undefined method `deprecator' for ActiveSupport:Module (NoMethodError)
```
Details: https://github.com/rails/rails/issues/49495

As per docs: https://guides.rubyonrails.org/active_support_core_extensions.html#cherry-picking-a-definition